### PR TITLE
Handles non affiliate/partner

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ async function closeIssue(client) {
       repo: github.context.repo.repo,
       issue_number: github.context.payload.issue.number,
       state: "closed"
-    })
+    });
   } catch (error) {
     core.setFailed(error.message);
   }
@@ -59,7 +59,7 @@ async function run() {
         let urls = github.context.payload.issue.body.match(/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/gm);
         console.log(`Has ${urls.length} urls in the body`);
         for (let index in urls) {
-          console.log(urls[index])
+          console.log(urls[index]);
           let url = new URL(urls[index]);
           if (url.host.includes('twitch.tv') && (url.pathname.match(/\//g) || []).length == 1) {
             let login = url.pathname.replace('/', '').toLowerCase();
@@ -67,14 +67,14 @@ async function run() {
             let result = await axios.get(`https://api.twitch.tv/helix/users?login=${login}`, { headers: { 'Client-Id': clientId } });
             
             if (result.data.data.length === 1) {
-              let user = result.data.data[0]
+              let user = result.data.data[0];
               const token = core.getInput('repo-token', {required: true});
               const client = new github.GitHub(token);
 
               if (user.broadcaster_type === 'affiliate' || user.broadcaster_type === 'partner') {
-                await addLabel(client, user.broadcaster_type)
+                await addLabel(client, user.broadcaster_type);
               } else {
-                console.log("User is not affiliate or partner yet. Commenting and closing issue.")
+                console.log("User is not affiliate or partner yet. Commenting and closing issue.");
                 await addComment(client, NOT_AFFILIATE_OR_PARTNER);
                 await closeIssue(client);
               }

--- a/index.js
+++ b/index.js
@@ -19,17 +19,24 @@ async function addLabel(client, labelName) {
   console.log(`End addLabel: ${labelName}`);
 }
 
-async function addCommentAndClose(client, comment) {
-  console.log(`Start addCommentAndClose ${comment}`);
+async function addComment(client, comment) {
+  console.log(`Start addComment ${comment}`);
   try {
-    console.log(`Adding comment: ${comment}`);
     await client.issues.createComment({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
       issue_number: github.context.payload.issue.number,
       body: comment
     });
-    console.log("Closing issue");
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+  console.log(`End addComment: ${comment}`);
+}
+
+async function closeIssue(client) {
+  console.log(`Start closeIssue`);
+  try {
     await client.issues.update({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
@@ -39,7 +46,7 @@ async function addCommentAndClose(client, comment) {
   } catch (error) {
     core.setFailed(error.message);
   }
-  console.log(`End addCommentAndClose: ${comment}`);
+  console.log(`End closeIssue`);
 }
 
 async function run() {
@@ -67,8 +74,9 @@ async function run() {
               if (user.broadcaster_type === 'affiliate' || user.broadcaster_type === 'partner') {
                 await addLabel(client, user.broadcaster_type)
               } else {
-                console.log("User is not affiliate or partner yet. Closing issue.")
-                await addCommentAndClose(client, NOT_AFFILIATE_OR_PARTNER);
+                console.log("User is not affiliate or partner yet. Commenting and closing issue.")
+                await addComment(client, NOT_AFFILIATE_OR_PARTNER);
+                await closeIssue(client);
               }
             }
           }

--- a/index.js
+++ b/index.js
@@ -19,8 +19,6 @@ async function addLabel(client, labelName) {
   console.log(`End addLabel: ${labelName}`);
 }
 
-const 
-
 async function addCommentAndClose(client, comment) {
   console.log(`Start addCommentAndClose ${comment}`);
   try {


### PR DESCRIPTION
If a user is not an affiliate or partner yet we want to close the application after adding a reason for closing the issue.

This PR creates a comment and then closes the issue.
Also has a small refactor to move the code that get the token and creates the Octokit client where all the methods can use it.

Considered attempting to tag the user, but would have to get the comments on the issue I believe.
Also unsure of how to test this.
