### PR TITLE
Skip clips.twitch.tv while retrieving user info

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ async function run() {
           for (let index in urls) {
             console.log(urls[index]);
             let url = new URL(urls[index]);
-            if (url.host.includes('twitch.tv') && (url.pathname.match(/\//g) || []).length == 1) {
+            if (url.host.includes('twitch.tv') && !url.host.includes('clips.twitch.tv') && (url.pathname.match(/\//g) || []).length == 1) {
               console.log('Twitch Url Found');
               found = true;
               let login = url.pathname.replace('/', '').toLowerCase();


### PR DESCRIPTION
Unfortunately, the link on clips don't contain the content author info, but author of clip. So, let's skip this URL